### PR TITLE
Complete olympian endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ script:
 
 before_script:
   - psql -c 'create database koroibos_test;' -U postgres
-  # - knex migrate:latest --env test
+  - knex migrate:latest --env test

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const environment = process.env.NODE_ENV || 'development';
 const configuration = require('./knexfile')[environment];
 
 var indexRouter = require('./routes/index');
+var olympiansRouter = require('./routes/api/v1/olympians');
 
 var app = express();
 
@@ -18,5 +19,6 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
+app.use('/api/v1/olympians', olympiansRouter.getAllOlympians)
 
 module.exports = app;

--- a/db/migrations/20200114085525_add_sport_to_olympians.js
+++ b/db/migrations/20200114085525_add_sport_to_olympians.js
@@ -1,0 +1,16 @@
+
+exports.up = function(knex) {
+  return Promise.all([
+    knex.schema.table('olympians', function(table) {
+      table.string('sport')
+    })
+  ])
+};
+
+exports.down = function(knex) {
+  return Promise.all([
+    knex.schema.table('olympians', function(table) {
+      table.dropColumn('sport')
+    })
+  ])
+};

--- a/models/olympian.js
+++ b/models/olympian.js
@@ -5,7 +5,8 @@ class Olympian {
     this.age = row.Age === 'NA' ? null : row.Age,
     this.height = row.Height === 'NA' ? null : row.Height,
     this.weight = row.Weight === 'NA' ? null : row.Weight,
-    this.team = row.Team === 'NA' ? null : row.Team
+    this.team = row.Team === 'NA' ? null : row.Team,
+    this.sport = row.Sport === 'NA' ? null : row.Sport
   }
 }
 

--- a/routes/api/v1/olympians.js
+++ b/routes/api/v1/olympians.js
@@ -6,11 +6,19 @@ const configuration = require('../../../knexfile')[environment];
 const database = require('knex')(configuration);
 
 const getAllOlympians = router.get('/', async (request, response) => {
+  if (request.query.age === 'youngest') {
+    additionalQuery = 'ORDER BY olympians.age ASC LIMIT 1'
+  } else if (request.query.age === 'oldest') {
+    additionalQuery = 'ORDER BY olympians.age DESC LIMIT 1'
+  } else {
+    additionalQuery = ''
+  }
   const olympians = await database.raw('SELECT name, team, age, sport, ' +
     'CAST(COUNT(CASE WHEN medal IS NOT NULL THEN 1 END) AS int) ' +
     'AS total_medals_won FROM olympians ' +
     'INNER JOIN olympian_events ON olympians.id = olympian_events.olympian_id ' +
-    'GROUP BY olympians.name, olympians.team, olympians.age, olympians.sport');
+    'GROUP BY olympians.name, olympians.team, olympians.age, olympians.sport ' +
+    additionalQuery);
   response.status(200).send({'olympians': olympians['rows']});
 })
 

--- a/routes/api/v1/olympians.js
+++ b/routes/api/v1/olympians.js
@@ -19,7 +19,11 @@ const getAllOlympians = router.get('/', async (request, response) => {
     'INNER JOIN olympian_events ON olympians.id = olympian_events.olympian_id ' +
     'GROUP BY olympians.name, olympians.team, olympians.age, olympians.sport ' +
     additionalQuery);
-  response.status(200).send({'olympians': olympians['rows']});
+  if (request.query.age === 'youngest' || request.query.age === 'oldest') {
+    response.status(200).json(olympians['rows']);
+  } else {
+    response.status(200).send({'olympians': olympians['rows']});
+  }
 })
 
 module.exports = {

--- a/routes/api/v1/olympians.js
+++ b/routes/api/v1/olympians.js
@@ -1,0 +1,15 @@
+var express = require('express');
+var router = express.Router();
+
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+const getAllOlympians = router.get('/', async (request, response) => {
+  const olympians = await database('olympians').select('name', 'team', 'age', 'sport');
+  response.status(200).send(olympians);
+})
+
+module.exports = {
+  getAllOlympians
+}

--- a/routes/api/v1/olympians.js
+++ b/routes/api/v1/olympians.js
@@ -6,8 +6,12 @@ const configuration = require('../../../knexfile')[environment];
 const database = require('knex')(configuration);
 
 const getAllOlympians = router.get('/', async (request, response) => {
-  const olympians = await database('olympians').select('name', 'team', 'age', 'sport');
-  response.status(200).send(olympians);
+  const olympians = await database.raw('SELECT name, team, age, sport, ' +
+    'CAST(COUNT(CASE WHEN medal IS NOT NULL THEN 1 END) AS int) ' +
+    'AS total_medals_won FROM olympians ' +
+    'INNER JOIN olympian_events ON olympians.id = olympian_events.olympian_id ' +
+    'GROUP BY olympians.name, olympians.team, olympians.age, olympians.sport');
+  response.status(200).send({'olympians': olympians['rows']});
 })
 
 module.exports = {

--- a/seedRunner.js
+++ b/seedRunner.js
@@ -8,6 +8,8 @@ const Olympian = require('./models/olympian')
 const Event = require('./models/event')
 const OlympianEvent = require('./models/olympianEvent')
 
+const seed = require('./seedRunnnerHelper')
+
 async function cleanTables() {
   await database.raw('TRUNCATE TABLE olympian_events CASCADE');
   await database.raw('TRUNCATE TABLE olympians CASCADE');
@@ -15,47 +17,13 @@ async function cleanTables() {
   console.log('Tables have been reset');
 }
 
-async function createOlympian(row) {
-  let olympian = new Olympian(row);
-  let existingOlympian = await database('olympians').where({name: row.Name});
-  if (existingOlympian[0]) {
-   return existingOlympian[0]
-  } else {
-   let newOlympian = await database('olympians').insert(olympian).returning('*');
-   return newOlympian[0];
-  }
-}
-
-async function createEvent(row) {
-  let event = new Event(row);
-  let existingEvent = await database('events').where({event: row.Event});
-  if (existingEvent[0]) {
-    return existingEvent[0]
-  } else {
-    let newEvent = await database('events').insert(event).returning('*');
-    return newEvent[0];
-  }
-}
-
-async function createOlympianEvent(row, olympian, event) {
-  let olympianEvent = new OlympianEvent(row, olympian, event);
-  let existingOlympianEvent = await database('olympian_events')
-    .where({olympian_id: olympian.id, event_id: event.id});
-  if (existingOlympianEvent[0]) {
-    return existingOlympianEvent[0]
-  } else {
-    let newOlympianEvent = await database('olympian_events').insert(olympianEvent).returning('*');
-    return newOlympianEvent[0];
-  }
-}
-
 async function seedTables(file) {
   await csv()
     .fromFile(file)
     .subscribe(async (row) => {
-      var olympian = await createOlympian(row);
-      var event = await createEvent(row);
-      var olympianEvent = await createOlympianEvent(row, olympian, event);
+      var olympian = await seed.createOlympian(row);
+      var event = await seed.createEvent(row);
+      var olympianEvent = await seed.createOlympianEvent(row, olympian, event);
     })
   console.log('Tables have been seeded')
 }

--- a/seedRunnerHelper.js
+++ b/seedRunnerHelper.js
@@ -1,0 +1,47 @@
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('./knexfile')[environment];
+const database = require('knex')(configuration);
+
+const Olympian = require('./models/olympian')
+const Event = require('./models/event')
+const OlympianEvent = require('./models/olympianEvent')
+
+async function createOlympian(row) {
+  let olympian = new Olympian(row);
+  let existingOlympian = await database('olympians').where({name: row.Name});
+  if (existingOlympian[0]) {
+   return existingOlympian[0]
+  } else {
+   let newOlympian = await database('olympians').insert(olympian).returning('*');
+   return newOlympian[0];
+  }
+}
+
+async function createEvent(row) {
+  let event = new Event(row);
+  let existingEvent = await database('events').where({event: row.Event});
+  if (existingEvent[0]) {
+    return existingEvent[0]
+  } else {
+    let newEvent = await database('events').insert(event).returning('*');
+    return newEvent[0];
+  }
+}
+
+async function createOlympianEvent(row, olympian, event) {
+  let olympianEvent = new OlympianEvent(row, olympian, event);
+  let existingOlympianEvent = await database('olympian_events')
+    .where({olympian_id: olympian.id, event_id: event.id});
+  if (existingOlympianEvent[0]) {
+    return existingOlympianEvent[0]
+  } else {
+    let newOlympianEvent = await database('olympian_events').insert(olympianEvent).returning('*');
+    return newOlympianEvent[0];
+  }
+}
+
+module.exports = {
+  createOlympian,
+  createEvent,
+  createOlympianEvent
+}

--- a/tests/olympians.spec.js
+++ b/tests/olympians.spec.js
@@ -1,0 +1,110 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test', () => {
+  beforeEach(async () => {
+    await database.raw('TRUNCATE TABLE olympian_events CASCADE');
+    await database.raw('TRUNCATE TABLE olympians CASCADE');
+    await database.raw('TRUNCATE TABLE events CASCADE');
+
+    const olympian1 = {
+      name: 'Aquaman',
+      sex: 'M',
+      age: 35,
+      height: 180,
+      weight: 96,
+      team: 'Superhero',
+      sport: 'Swimming'
+    }
+
+    const olympian2 = {
+      name: 'Michael Phelps',
+      sex: 'M',
+      age: 32,
+      height: 176,
+      weight: 80,
+      team: 'Human',
+      sport: 'Swimming'
+    }
+
+    const olympian3 = {
+      name: 'Little Mermaid',
+      sex: 'F',
+      age: 24,
+      height: 140,
+      weight: 62,
+      team: 'Mermaid',
+      sport: 'Swimming'
+    }
+
+    const event1 = {
+      sport: 'Swimming',
+      event: '100m Fly'
+    }
+
+    const event2 = {
+      sport: 'Swimming',
+      event: '5000m Freestyle'
+    }
+
+    let aquaman = await database('olympians').insert(olympian1, 'id')
+    let phelps = await database('olympians').insert(olympian2, 'id')
+    let mermaid = await database('olympians').insert(olympian3, 'id')
+
+    let fly = await database('events').insert(event1, 'id')
+    let free = await database('events').insert(event2, 'id')
+
+    const olympianEvent1 = {
+      olympian_id: aquaman.id,
+      event_id: fly.id,
+      medal: 'Gold'
+    }
+
+    const olympianEvent2 = {
+      olympian_id: aquaman.id,
+      event_id: free.id,
+      medal: 'Bronze'
+    }
+
+    const olympianEvent3 = {
+      olympian_id: mermaid.id,
+      event_id: fly.id,
+      medal: 'Silver'
+    }
+    const olympianEvent4 = {
+      olympian_id: phelps.id,
+      event_id: fly.id,
+      medal: 'Silver'
+    }
+    const olympianEvent5 = {
+      olympian_id: phelps.id,
+      event_id: free.id,
+      medal: 'Gold'
+    }
+
+    await database('olympian_events').insert(olympianEvent1, 'id')
+    await database('olympian_events').insert(olympianEvent2, 'id')
+    await database('olympian_events').insert(olympianEvent3, 'id')
+    await database('olympian_events').insert(olympianEvent4, 'id')
+    await database('olympian_events').insert(olympianEvent5, 'id')
+  })
+
+  afterEach(() => {
+    database.raw('TRUNCATE TABLE olympian_events CASCADE');
+    database.raw('TRUNCATE TABLE olympians CASCADE');
+    database.raw('TRUNCATE TABLE events CASCADE');
+  })
+
+  describe('GET all olympians', () => {
+    it('from the olympians endpoint', async () => {
+      const res = await request(app).get('/api/v1/olympians');
+
+      expect(res.statusCode).toBe(200);
+    })
+  })
+})

--- a/tests/olympians.spec.js
+++ b/tests/olympians.spec.js
@@ -6,92 +6,60 @@ const environment = process.env.NODE_ENV || 'test';
 const configuration = require('../knexfile')[environment];
 const database = require('knex')(configuration);
 
+const seed = require('../seedRunnerHelper')
+
 describe('Test', () => {
   beforeEach(async () => {
     await database.raw('TRUNCATE TABLE olympian_events CASCADE');
     await database.raw('TRUNCATE TABLE olympians CASCADE');
     await database.raw('TRUNCATE TABLE events CASCADE');
 
-    const olympian1 = {
-      name: 'Aquaman',
-      sex: 'M',
-      age: 35,
-      height: 180,
-      weight: 96,
-      team: 'Superhero',
-      sport: 'Swimming'
+    const row1 = {
+      Name: 'Aquaman',
+      Sex: 'M',
+      Age: 35,
+      Height: 180,
+      Weight: 96,
+      Team: 'Superhero',
+      Sport: 'Swimming',
+      Event: '100m Fly',
+      Medal: 'Gold'
     }
 
-    const olympian2 = {
-      name: 'Michael Phelps',
-      sex: 'M',
-      age: 32,
-      height: 176,
-      weight: 80,
-      team: 'Human',
-      sport: 'Swimming'
+    const row2 = {
+      Name: 'Michael Phelps',
+      Sex: 'M',
+      Age: 32,
+      Height: 176,
+      Weight: 80,
+      Team: 'Human',
+      Sport: 'Swimming',
+      Event: '5000m Freestyle',
+      Medal: 'Silver'
     }
 
-    const olympian3 = {
-      name: 'Little Mermaid',
-      sex: 'F',
-      age: 24,
-      height: 140,
-      weight: 62,
-      team: 'Mermaid',
-      sport: 'Swimming'
+    const row3 = {
+      Name: 'Little Mermaid',
+      Sex: 'F',
+      Age: 24,
+      Height: 140,
+      Weight: 62,
+      Team: 'Mermaid',
+      Sport: 'Swimming',
+      Event: '100m Fly',
+      Medal: 'Bronze'
     }
 
-    const event1 = {
-      sport: 'Swimming',
-      event: '100m Fly'
-    }
+    let aquaman = await seed.createOlympian(row1);
+    let phelps = await seed.createOlympian(row2);
+    let mermaid = await seed.createOlympian(row3);
 
-    const event2 = {
-      sport: 'Swimming',
-      event: '5000m Freestyle'
-    }
+    let fly = await seed.createEvent(row1);
+    let free = await seed.createEvent(row2);
 
-    let aquaman = await database('olympians').insert(olympian1, 'id')
-    let phelps = await database('olympians').insert(olympian2, 'id')
-    let mermaid = await database('olympians').insert(olympian3, 'id')
-
-    let fly = await database('events').insert(event1, 'id')
-    let free = await database('events').insert(event2, 'id')
-
-    const olympianEvent1 = {
-      olympian_id: aquaman.id,
-      event_id: fly.id,
-      medal: 'Gold'
-    }
-
-    const olympianEvent2 = {
-      olympian_id: aquaman.id,
-      event_id: free.id,
-      medal: 'Bronze'
-    }
-
-    const olympianEvent3 = {
-      olympian_id: mermaid.id,
-      event_id: fly.id,
-      medal: 'Silver'
-    }
-    const olympianEvent4 = {
-      olympian_id: phelps.id,
-      event_id: fly.id,
-      medal: 'Silver'
-    }
-    const olympianEvent5 = {
-      olympian_id: phelps.id,
-      event_id: free.id,
-      medal: 'Gold'
-    }
-
-    await database('olympian_events').insert(olympianEvent1, 'id')
-    await database('olympian_events').insert(olympianEvent2, 'id')
-    await database('olympian_events').insert(olympianEvent3, 'id')
-    await database('olympian_events').insert(olympianEvent4, 'id')
-    await database('olympian_events').insert(olympianEvent5, 'id')
+    await seed.createOlympianEvent(row1, aquaman, fly);
+    await seed.createOlympianEvent(row2, phelps, free);
+    await seed.createOlympianEvent(row3, mermaid, fly);
   })
 
   afterEach(() => {
@@ -105,6 +73,8 @@ describe('Test', () => {
       const res = await request(app).get('/api/v1/olympians');
 
       expect(res.statusCode).toBe(200);
+      expect(res.body).toHaveProperty('olympians');
+      expect(res.body.olympians.length).toBe(3);
     })
   })
 })

--- a/tests/olympians.spec.js
+++ b/tests/olympians.spec.js
@@ -68,13 +68,40 @@ describe('Test', () => {
     database.raw('TRUNCATE TABLE events CASCADE');
   })
 
-  describe('GET all olympians', () => {
+  describe('GET olympian(s)', () => {
     it('from the olympians endpoint', async () => {
       const res = await request(app).get('/api/v1/olympians');
 
       expect(res.statusCode).toBe(200);
       expect(res.body).toHaveProperty('olympians');
       expect(res.body.olympians.length).toBe(3);
+      expect(res.body.olympians[0].name).toBe('Little Mermaid');
+      expect(res.body.olympians[0].team).toBe('Mermaid');
+      expect(res.body.olympians[0].age).toBe(24);
+      expect(res.body.olympians[0].sport).toBe('Swimming');
+      expect(res.body.olympians[0].total_medals_won).toBe(1)
+    })
+
+    it('that is the youngest', async() => {
+      const res = await request(app).get('/api/v1/olympians?age=youngest');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body[0].name).toBe('Little Mermaid');
+      expect(res.body[0].team).toBe('Mermaid');
+      expect(res.body[0].age).toBe(24);
+      expect(res.body[0].sport).toBe('Swimming');
+      expect(res.body[0].total_medals_won).toBe(1)
+    })
+
+    it('that is the oldest', async() => {
+      const res = await request(app).get('/api/v1/olympians?age=oldest');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body[0].name).toBe('Aquaman');
+      expect(res.body[0].team).toBe('Superhero');
+      expect(res.body[0].age).toBe(35);
+      expect(res.body[0].sport).toBe('Swimming');
+      expect(res.body[0].total_medals_won).toBe(1)
     })
   })
 })


### PR DESCRIPTION
### Functionality
- Create `/api/v1/olympians` endpoint that can be appended with the queries `age=youngest` or `age=oldest`
- Modified the olympians table with a migration to include sport 

### Testing
- Added tests for the base endpoint and the 2 queries
- In order to seed the test database, I moved the 3 methods for creating resources from the seedRunner to a seedRunnerHelper file.

### Comments
- The new migration will need to be migrated in production
- I added in a knex command to the travis config so travis has the latest migrations to run the tests