### PR TITLE
Complete events endpoints

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,5 +24,6 @@ app.use('/', indexRouter);
 app.use('/api/v1/olympians', olympiansRouter.getAllOlympians)
 app.use('/api/v1/olympian_stats', olympianStatsRouter.getOlympianStats)
 app.use('/api/v1/events', eventsRouter.getAllEvents)
+app.use('/api/v1/events', eventsRouter.getEventMedalists)
 
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ const configuration = require('./knexfile')[environment];
 var indexRouter = require('./routes/index');
 var olympiansRouter = require('./routes/api/v1/olympians');
 var olympianStatsRouter = require('./routes/api/v1/olympianStats');
+var eventsRouter = require('./routes/api/v1/events');
 
 var app = express();
 
@@ -22,5 +23,6 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', indexRouter);
 app.use('/api/v1/olympians', olympiansRouter.getAllOlympians)
 app.use('/api/v1/olympian_stats', olympianStatsRouter.getOlympianStats)
+app.use('/api/v1/events', eventsRouter.getAllEvents)
 
 module.exports = app;

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -1,0 +1,14 @@
+var express = require('express');
+var router = express.Router();
+
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+const getAllEvents = router.get('/', async (request, response) => {
+  response.status(200).send({'events': []});
+})
+
+module.exports = {
+  getAllEvents
+}

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -5,8 +5,21 @@ const environment = process.env.NODE_ENV || 'development';
 const configuration = require('../../../knexfile')[environment];
 const database = require('knex')(configuration);
 
+async function getAllEventsBySport() {
+  var allSports = await database('events').select('sport').distinct()
+  var finalArray = await Promise.all(allSports.map(async (sport_hash) => {
+    var events = await database('events').where({sport: sport_hash.sport}).select('event').distinct()
+    var eventsArray = await Promise.all(events.map(async (event_hash) => {
+      return event_hash.event
+    }))
+    return {'sport': sport_hash.sport, 'events': eventsArray}
+  }))
+  return finalArray
+}
+
 const getAllEvents = router.get('/', async (request, response) => {
-  response.status(200).send({'events': []});
+  const data = await getAllEventsBySport()
+  response.status(200).send({'events': data});
 })
 
 module.exports = {

--- a/tests/events.spec.js
+++ b/tests/events.spec.js
@@ -83,4 +83,21 @@ describe('Test', () => {
       expect(res.body.events[0].events[1]).toBe('5000m Freestyle');
     })
   })
+
+  describe('GET an event and its medalists', () => {
+    it('from the event medalist endpoint', async () => {
+      let fly_event = await database('events').where({event: '100m Fly'}).select('id')
+      const res = await request(app).get(`/api/v1/events/${fly_event}/medalists`)
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toHaveProperty('event');
+      expect(res.body.event).toBe('100m Fly');
+      expect(res.body).toHaveProperty('medalists');
+      expect(res.body.medalists.length).toBe(2);
+      expect(res.body.medalists[0].name).toBe('Aquaman');
+      expect(res.body.medalists[0].team).toBe('Superhero');
+      expect(res.body.medalists[0].age).toBe(35);
+      expect(res.body.medalists[0].medal).toBe('Gold');  
+    })
+  })
 })

--- a/tests/events.spec.js
+++ b/tests/events.spec.js
@@ -85,7 +85,7 @@ describe('Test', () => {
   })
 
   describe('GET an event and its medalists', () => {
-    it('from the event medalist endpoint', async () => {
+    it('by passing in a valid event id', async () => {
       const flyEvent = await database('events').where({event: '100m Fly'}).select('id')
       const flyEventId = flyEvent[0].id
       const res = await request(app).get(`/api/v1/events/${flyEventId}/medalists`)
@@ -99,6 +99,16 @@ describe('Test', () => {
       expect(res.body.medalists[0].team).toBe('Superhero');
       expect(res.body.medalists[0].age).toBe(35);
       expect(res.body.medalists[0].medal).toBe('Gold');
+    })
+
+    it('returns an error if the id is invalid', async () => {
+      const flyEvent = await database('events').where({event: '100m Fly'}).select('id')
+      const flyEventId = flyEvent[0].id
+      const wrongId = flyEventId + 100
+      const res = await request(app).get(`/api/v1/events/${wrongId}/medalists`)
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.error).toBe('Event not found')
     })
   })
 })

--- a/tests/events.spec.js
+++ b/tests/events.spec.js
@@ -1,0 +1,86 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+const seed = require('../seedRunnerHelper')
+
+describe('Test', () => {
+  beforeEach(async () => {
+    await database.raw('TRUNCATE TABLE olympian_events CASCADE');
+    await database.raw('TRUNCATE TABLE olympians CASCADE');
+    await database.raw('TRUNCATE TABLE events CASCADE');
+
+    const row1 = {
+      Name: 'Aquaman',
+      Sex: 'M',
+      Age: 35,
+      Height: 180,
+      Weight: 96,
+      Team: 'Superhero',
+      Sport: 'Swimming',
+      Event: '100m Fly',
+      Medal: 'Gold'
+    }
+
+    const row2 = {
+      Name: 'Michael Phelps',
+      Sex: 'M',
+      Age: 32,
+      Height: 176,
+      Weight: 80,
+      Team: 'Human',
+      Sport: 'Swimming',
+      Event: '5000m Freestyle',
+      Medal: 'Silver'
+    }
+
+    const row3 = {
+      Name: 'Little Mermaid',
+      Sex: 'F',
+      Age: 24,
+      Height: 140,
+      Weight: 62,
+      Team: 'Mermaid',
+      Sport: 'Swimming',
+      Event: '100m Fly',
+      Medal: 'Bronze'
+    }
+
+    let aquaman = await seed.createOlympian(row1);
+    let phelps = await seed.createOlympian(row2);
+    let mermaid = await seed.createOlympian(row3);
+
+    let fly = await seed.createEvent(row1);
+    let free = await seed.createEvent(row2);
+
+    await seed.createOlympianEvent(row1, aquaman, fly);
+    await seed.createOlympianEvent(row2, phelps, free);
+    await seed.createOlympianEvent(row3, mermaid, fly);
+  })
+
+  afterEach(() => {
+    database.raw('TRUNCATE TABLE olympian_events CASCADE');
+    database.raw('TRUNCATE TABLE olympians CASCADE');
+    database.raw('TRUNCATE TABLE events CASCADE');
+  })
+
+  describe('GET all events', () => {
+    it('from the events endpoint', async () => {
+      const res = await request(app).get('/api/v1/events');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toHaveProperty('events');
+      expect(res.body.events.length).toBe(1);
+      expect(res.body.events[0]).toHaveProperty('sport');
+      expect(res.body.events[0].sport).toBe('Swimming');
+      expect(res.body.events[0]).toHaveProperty('events');
+      expect(res.body.events[0].events.length).toBe(2);
+      expect(res.body.events[0].events[0]).toBe('100m Fly');
+      expect(res.body.events[0].events[1]).toBe('5000m Freestyle');
+    })
+  })
+})

--- a/tests/events.spec.js
+++ b/tests/events.spec.js
@@ -86,8 +86,9 @@ describe('Test', () => {
 
   describe('GET an event and its medalists', () => {
     it('from the event medalist endpoint', async () => {
-      let fly_event = await database('events').where({event: '100m Fly'}).select('id')
-      const res = await request(app).get(`/api/v1/events/${fly_event}/medalists`)
+      const flyEvent = await database('events').where({event: '100m Fly'}).select('id')
+      const flyEventId = flyEvent[0].id
+      const res = await request(app).get(`/api/v1/events/${flyEventId}/medalists`)
 
       expect(res.statusCode).toBe(200);
       expect(res.body).toHaveProperty('event');
@@ -97,7 +98,7 @@ describe('Test', () => {
       expect(res.body.medalists[0].name).toBe('Aquaman');
       expect(res.body.medalists[0].team).toBe('Superhero');
       expect(res.body.medalists[0].age).toBe(35);
-      expect(res.body.medalists[0].medal).toBe('Gold');  
+      expect(res.body.medalists[0].medal).toBe('Gold');
     })
   })
 })


### PR DESCRIPTION
### Functionality:
- Completed `/api/v1/events` endpoint with customized response configuration
- Completed `/api/v1/events/:id/medalists` with customized response configuration

### Testing:
- Tested `/api/v1/events`
- Tested `/api/v1/events/:id/medalists` for both happy and sad path (invalid event id)

### Comments:
- When writing orderByRaw queries, put double quotes on the outside of the query and single quotes on the internal pieces